### PR TITLE
Resolve compatibility issues after new ddr release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>ddr</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.11</version>
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>

--- a/src/main/kotlin/org/objectionary/aoi/launch/AoiWorkflow.kt
+++ b/src/main/kotlin/org/objectionary/aoi/launch/AoiWorkflow.kt
@@ -30,11 +30,10 @@ import org.objectionary.aoi.process.InstanceUsageProcessor
 import org.objectionary.aoi.transformer.XmirTransformer
 import org.objectionary.ddr.graph.AttributesSetter
 import org.objectionary.ddr.graph.CondAttributesSetter
-import org.objectionary.ddr.graph.GraphBuilder
 import org.objectionary.ddr.graph.InnerPropagator
-import org.objectionary.ddr.sources.SrsTransformed
-import org.objectionary.ddr.transform.XslTransformer
+import org.objectionary.ddr.launch.XmirAnalysisWorkflow
 import org.w3c.dom.Document
+import java.nio.file.Path
 
 /**
  * Stores all the information from xmir files in the form of a graph. Launches various analysis or transformation steps
@@ -45,9 +44,13 @@ import org.w3c.dom.Document
 /* todo #54:30min this class is almost copy-paste of DdrWorkflow class from ddr repository. So Workflow interface and
     AnalysisWorkflow base class should be created in ddr repository. After next ddr release this class should be
     rewritten. */
-class AoiWorkflow(val documents: MutableMap<Document, String>) {
-    /** @property graph decoration hierarchy graph of xmir files from analyzed directory */
-    private val graph = GraphBuilder(documents).createGraph()
+class AoiWorkflow : XmirAnalysisWorkflow {
+    /**
+     * Constructs workflow class using documents
+     *
+     * @param documents all documents from analyzed directory
+     */
+    constructor(documents: MutableMap<Document, Path>) : super(documents)
 
     /**
      * Constructs [documents] from [path]
@@ -55,13 +58,12 @@ class AoiWorkflow(val documents: MutableMap<Document, String>) {
      * @param path path to the directory to be analysed
      * @param postfix postfix of the resulting directory
      */
-    constructor(path: String, postfix: String = "aoi") : this(
-        SrsTransformed(path, XslTransformer(), postfix, false).walk())
+    constructor(path: String, postfix: String = "aoi") : super(path, postfix)
 
     /**
      * Aggregates all steps of analysis
      */
-    fun launch() {
+    override fun launch() {
         CondAttributesSetter(graph).processConditions()
         AttributesSetter(graph).setAttributes()
         AtomsProcessor(graph).processAtoms()

--- a/src/main/kotlin/org/objectionary/aoi/process/AtomsProcessor.kt
+++ b/src/main/kotlin/org/objectionary/aoi/process/AtomsProcessor.kt
@@ -26,11 +26,9 @@ package org.objectionary.aoi.process
 
 import org.objectionary.aoi.data.FreeAtomAttribute
 import org.objectionary.aoi.data.FreeAttributesHolder
-import org.objectionary.ddr.graph.abstract
-import org.objectionary.ddr.graph.base
-import org.objectionary.ddr.graph.line
-import org.objectionary.ddr.graph.name
 import org.objectionary.ddr.graph.repr.Graph
+import org.objectionary.ddr.util.containsAttr
+import org.objectionary.ddr.util.getAttrContent
 import org.slf4j.LoggerFactory
 import org.w3c.dom.Document
 import javax.xml.parsers.DocumentBuilderFactory
@@ -48,7 +46,7 @@ class AtomsProcessor(private val graph: Graph) {
     fun processAtoms() {
         graph.initialObjects.forEach { obj ->
             obj.attributes?.getNamedItem("atom")?.textContent?.let { atom ->
-                name(obj)?.let { name ->
+                obj.getAttrContent("name")?.let { name ->
                     val docObjects = getAtomsDocument()?.getElementsByTagName("atom") ?: return@forEach
                     val fqn = "$atom.$name"
                     for (i in 0 until docObjects.length) {
@@ -61,14 +59,15 @@ class AtomsProcessor(private val graph: Graph) {
                                 if (ch.attributes == null || ch.attributes.length == 0) {
                                     continue
                                 }
-                                if (base(ch) == null && name(ch) != null && abstract(ch) == null &&
-                                        (line(ch) == line(obj) || line(ch)?.toInt() == line(obj)?.toInt()?.plus(1))
+                                if (!ch.containsAttr("base") && ch.containsAttr("name") && !ch.containsAttr("abstract") &&
+                                        (ch.getAttrContent("line") == obj.getAttrContent("line") ||
+                                                ch.getAttrContent("line")?.toInt() == obj.getAttrContent("line")?.toInt()?.plus(1))
                                 ) {
-                                    val freeAtomAttr = FreeAtomAttribute(name(ch)!!, obj)
+                                    val freeAtomAttr = FreeAtomAttribute(ch.getAttrContent("name")!!, obj)
                                     val objects = atomNode.childNodes.item(3).childNodes
                                     for (k in 0 until objects.length) {
                                         val objNode = objects.item(k)
-                                        name(objNode)?.let { freeAtomAttr.atomRestrictions.add(it) }
+                                        objNode.getAttrContent("name")?.let { freeAtomAttr.atomRestrictions.add(it) }
                                     }
                                     FreeAttributesHolder.storage.add(freeAtomAttr)
                                 }

--- a/src/main/kotlin/org/objectionary/aoi/process/InitializationProcessor.kt
+++ b/src/main/kotlin/org/objectionary/aoi/process/InitializationProcessor.kt
@@ -26,10 +26,9 @@ package org.objectionary.aoi.process
 
 import org.objectionary.aoi.data.FreeAttributesHolder
 import org.objectionary.aoi.data.Parameter
-import org.objectionary.ddr.graph.base
-import org.objectionary.ddr.graph.findRef
-import org.objectionary.ddr.graph.name
 import org.objectionary.ddr.graph.repr.Graph
+import org.objectionary.ddr.util.findRef
+import org.objectionary.ddr.util.getAttrContent
 
 /**
  * Processes objects which are used to initialize free attributes
@@ -40,12 +39,12 @@ class InitializationProcessor(private val graph: Graph) {
      */
     fun processInitializations() {
         graph.initialObjects.forEach { obj ->
-            if (graph.igNodes.map { it.name }.contains(base(obj))) {
+            if (graph.igNodes.map { it.name }.contains(obj.getAttrContent("base"))) {
                 val abstract = findRef(obj, graph.initialObjects, graph) ?: return@forEach
                 val children = obj.childNodes
                 for (i in 0 until children.length) {
                     val ch = children.item(i)
-                    val param = FreeAttributesHolder.storage.find { it.name == name(abstract.childNodes.item(i)) && it.holderObject == abstract } ?: continue
+                    val param = FreeAttributesHolder.storage.find { it.name == abstract.childNodes.item(i).getAttrContent("name") && it.holderObject == abstract } ?: continue
                     val ref = findRef(ch, graph.initialObjects, graph) ?: continue
                     val dgAbstract = graph.igNodes.find { it.body == ref } ?: continue
                     dgAbstract.attributes.forEach { param.appliedAttributes.add(Parameter(".${it.name}")) }

--- a/src/main/kotlin/org/objectionary/aoi/process/InnerUsageProcessor.kt
+++ b/src/main/kotlin/org/objectionary/aoi/process/InnerUsageProcessor.kt
@@ -27,11 +27,9 @@ package org.objectionary.aoi.process
 import org.objectionary.aoi.data.FreeAttribute
 import org.objectionary.aoi.data.FreeAttributesHolder
 import org.objectionary.aoi.data.Parameter
-import org.objectionary.ddr.graph.abstract
-import org.objectionary.ddr.graph.base
-import org.objectionary.ddr.graph.line
-import org.objectionary.ddr.graph.name
 import org.objectionary.ddr.graph.repr.Graph
+import org.objectionary.ddr.util.containsAttr
+import org.objectionary.ddr.util.getAttrContent
 import org.w3c.dom.Node
 
 /**
@@ -58,16 +56,17 @@ class InnerUsageProcessor(private val graph: Graph) {
                     continue
                 }
                 deepTraversal(ch, origNode)
-                if (base(ch) == null && name(ch) != null && abstract(ch) == null &&
-                        (line(ch) == line(node) || line(ch)?.toInt() == line(node)?.toInt()?.plus(1))
+                if (!ch.containsAttr("base") && ch.containsAttr("name") && !ch.containsAttr("abstract") &&
+                        (ch.getAttrContent("line") == node.getAttrContent("line") ||
+                                ch.getAttrContent("line")?.toInt() == node.getAttrContent("line")?.toInt()?.plus(1))
                 ) {
-                    FreeAttributesHolder.storage.find { it.name == name(ch)!! && it.holderObject == origNode }
-                        ?: FreeAttributesHolder.storage.add(FreeAttribute(name(ch)!!, origNode))
+                    FreeAttributesHolder.storage.find { it.name == ch.getAttrContent("name")!! && it.holderObject == origNode }
+                        ?: FreeAttributesHolder.storage.add(FreeAttribute(ch.getAttrContent("name")!!, origNode))
                 }
-                base(ch)?.let {
-                    FreeAttributesHolder.storage.find { it.name == base(ch) && it.holderObject == origNode }
+                ch.getAttrContent("base")?.let {
+                    FreeAttributesHolder.storage.find { it.name == ch.getAttrContent("base") && it.holderObject == origNode }
                         ?.let { fa ->
-                            base(ch.nextSibling.nextSibling)?.let {
+                            ch.nextSibling.nextSibling.getAttrContent("base")?.let {
                                 fa.appliedAttributes.add(Parameter(it))
                             }
                         }

--- a/src/main/kotlin/org/objectionary/aoi/transformer/XmirTransformer.kt
+++ b/src/main/kotlin/org/objectionary/aoi/transformer/XmirTransformer.kt
@@ -26,14 +26,15 @@ package org.objectionary.aoi.transformer
 
 import org.objectionary.aoi.data.FreeAtomAttribute
 import org.objectionary.aoi.data.FreeAttributesHolder
-import org.objectionary.ddr.graph.name
 import org.objectionary.ddr.graph.repr.Graph
+import org.objectionary.ddr.util.getAttrContent
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.io.FileOutputStream
 import java.io.OutputStream
 import java.io.UnsupportedEncodingException
+import java.nio.file.Path
 import javax.xml.transform.OutputKeys
 import javax.xml.transform.TransformerException
 import javax.xml.transform.TransformerFactory
@@ -46,7 +47,7 @@ import javax.xml.transform.stream.StreamSource
  */
 class XmirTransformer(
     private val graph: Graph,
-    private val documents: MutableMap<Document, String>
+    private val documents: MutableMap<Document, Path>
 ) {
     /**
      * Aggregates the process of adding an aoi section to xmir documents
@@ -111,8 +112,8 @@ class XmirTransformer(
     private fun getFqn(name: String, par: Node): String {
         var fqn = name
         var parent = par
-        while (name(parent) != null) {
-            fqn = "${name(parent)}.$fqn"
+        while (parent.getAttrContent("name") != null) {
+            fqn = "${parent.getAttrContent("name")}.$fqn"
             parent = parent.parentNode
         }
         return fqn
@@ -120,7 +121,7 @@ class XmirTransformer(
 
     private fun transformDocuments() {
         documents.forEach { doc ->
-            val outputStream = FileOutputStream(doc.value)
+            val outputStream = FileOutputStream(doc.value.toFile())
             outputStream.use { writeXml(it, doc.key) }
         }
     }

--- a/src/test/kotlin/org/objectionary/aoi/TestBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/TestBase.kt
@@ -25,6 +25,7 @@
 package org.objectionary.aoi
 
 import java.io.File
+import java.nio.file.Path
 import kotlin.test.assertEquals
 
 /**
@@ -63,13 +64,14 @@ interface TestBase {
      * @param directoryName name of the input directory
      * @return path to input location
      */
-    fun constructInPath(directoryName: String): String = "src${sep}test${sep}resources${sep}unit${sep}in$sep$directoryName"
+    fun constructInPath(directoryName: String): Path =
+        Path.of("src${sep}test${sep}resources${sep}unit${sep}in$sep$directoryName")
 
     /**
      * @param directoryName name of the output directory
      * @return path to output location
      */
-    fun constructOutPath(directoryName: String): String
+    fun constructOutPath(directoryName: String): Path
 
     /**
      * @return name of the test being executed

--- a/src/test/kotlin/org/objectionary/aoi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/integration/IntegrationTestBase.kt
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory
 import java.io.BufferedReader
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 
 /**
  * Base class for testing decorators resolver
@@ -41,12 +41,12 @@ open class IntegrationTestBase : TestBase {
 
     override fun doTest() {
         val path = getTestName()
-        AoiWorkflow(constructInPath(path)).launch()
+        AoiWorkflow(constructInPath(path).toString()).launch()
         val actualFiles: MutableList<String> = mutableListOf()
-        Files.walk(Paths.get(constructOutPath(path)))
+        Files.walk(constructOutPath(path))
             .filter(Files::isRegularFile)
             .forEach { actualFiles.add(it.toString()) }
-        Files.walk(Paths.get(constructResultPath(path)))
+        Files.walk(constructResultPath(path))
             .filter(Files::isRegularFile)
             .forEach { file ->
                 val actualBr: BufferedReader = File(file.toString()).bufferedReader()
@@ -60,25 +60,25 @@ open class IntegrationTestBase : TestBase {
             }
         try {
             val tmpDir =
-                Paths.get((constructResultPath(path))).toString()
+                (constructResultPath(path)).toString()
             FileUtils.deleteDirectory(File(tmpDir))
         } catch (e: Exception) {
             logger.error(e.printStackTrace().toString())
         }
     }
 
-    override fun constructOutPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructOutPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}integration${sep}out$sep$directoryName")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
-    override fun constructInPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructInPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}integration${sep}in$sep$directoryName")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
-    private fun constructResultPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    private fun constructResultPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}integration${sep}in$sep${directoryName}_aoi")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 }

--- a/src/test/kotlin/org/objectionary/aoi/unit/UnitTestBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/unit/UnitTestBase.kt
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory
 import java.io.BufferedReader
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
@@ -50,7 +51,7 @@ open class UnitTestBase : TestBase {
         val path = getTestName()
         FreeAttributesHolder.storage.clear()
         val graph = GraphBuilder(
-            SrsTransformed(constructInPath(path), XslTransformer(), "aoi", false).walk()).createGraph()
+            SrsTransformed(constructInPath(path), XslTransformer(), "aoi").walk()).createGraph()
         CondAttributesSetter(graph).processConditions()
         AttributesSetter(graph).setAttributes()
         InnerPropagator(graph).propagateInnerAttrs()
@@ -58,14 +59,14 @@ open class UnitTestBase : TestBase {
         val out = ByteArrayOutputStream()
         printAttributes(out)
         val actual = String(out.toByteArray())
-        val bufferedReader: BufferedReader = File(constructOutPath(path)).bufferedReader()
+        val bufferedReader: BufferedReader = constructOutPath(path).toFile().bufferedReader()
         val expected = bufferedReader.use { it.readText() }
         logger.debug(actual)
         checkOutput(expected, actual)
         try {
             val tmpDir =
                 Paths.get(
-                    "${constructInPath(path).replace('/', sep).substringBeforeLast(sep)}${sep}TMP"
+                    "${constructInPath(path).toString().replace('/', sep).substringBeforeLast(sep)}${sep}TMP"
                 ).toString()
             FileUtils.deleteDirectory(File(tmpDir))
         } catch (e: Exception) {
@@ -93,5 +94,5 @@ open class UnitTestBase : TestBase {
         }
     }
 
-    override fun constructOutPath(directoryName: String) = ""
+    override fun constructOutPath(directoryName: String): Path = Path.of("")
 }

--- a/src/test/kotlin/org/objectionary/aoi/unit/atoms/AtomsBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/unit/atoms/AtomsBase.kt
@@ -30,10 +30,11 @@ import org.objectionary.aoi.process.AtomsProcessor
 import org.objectionary.aoi.process.InnerUsageProcessor
 import org.objectionary.aoi.process.InstanceUsageProcessor
 import org.objectionary.aoi.unit.UnitTestBase
-import org.objectionary.ddr.graph.name
 import org.objectionary.ddr.graph.repr.Graph
+import org.objectionary.ddr.util.getAttrContent
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.Path
 
 /**
  * Base class for graph builder testing
@@ -45,19 +46,19 @@ open class AtomsBase : UnitTestBase() {
         InstanceUsageProcessor(graph).processInstanceUsages()
     }
 
-    override fun constructOutPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructOutPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}out${sep}atoms$sep$directoryName.txt")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
-    override fun constructInPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructInPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}in${sep}atoms$sep$directoryName")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
     override fun printAttributes(out: ByteArrayOutputStream) {
         FreeAttributesHolder.storage.forEach { attr ->
-            out.writeBytes("ATTR (${if (attr is FreeAtomAttribute) "atom" else "not atom"}): _${name(attr.holderObject)}.${attr.name}_".toByteArray())
+            out.writeBytes("ATTR (${if (attr is FreeAtomAttribute) "atom" else "not atom"}): _${attr.holderObject.getAttrContent("name")}.${attr.name}_".toByteArray())
             attr.appliedAttributes.forEach { out.writeBytes(it.name.toByteArray()) }
         }
     }

--- a/src/test/kotlin/org/objectionary/aoi/unit/init/InitBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/unit/init/InitBase.kt
@@ -30,6 +30,7 @@ import org.objectionary.aoi.process.InstanceUsageProcessor
 import org.objectionary.aoi.unit.UnitTestBase
 import org.objectionary.ddr.graph.repr.Graph
 import java.io.File
+import java.nio.file.Path
 
 /**
  * Base class for graph builder testing
@@ -41,13 +42,13 @@ open class InitBase : UnitTestBase() {
         InitializationProcessor(graph).processInitializations()
     }
 
-    override fun constructOutPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructOutPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}out${sep}init$sep$directoryName.txt")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
-    override fun constructInPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructInPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}in${sep}init$sep$directoryName")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 }

--- a/src/test/kotlin/org/objectionary/aoi/unit/inner/InnerUsageBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/unit/inner/InnerUsageBase.kt
@@ -28,6 +28,7 @@ import org.objectionary.aoi.process.InnerUsageProcessor
 import org.objectionary.aoi.unit.UnitTestBase
 import org.objectionary.ddr.graph.repr.Graph
 import java.io.File
+import java.nio.file.Path
 
 /**
  * Base class for graph builder testing
@@ -37,13 +38,13 @@ open class InnerUsageBase : UnitTestBase() {
         InnerUsageProcessor(graph).processInnerUsages()
     }
 
-    override fun constructOutPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructOutPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}out${sep}inner_usages$sep$directoryName.txt")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
-    override fun constructInPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructInPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}in${sep}inner_usages$sep$directoryName")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 }

--- a/src/test/kotlin/org/objectionary/aoi/unit/instance/InstanceUsageBase.kt
+++ b/src/test/kotlin/org/objectionary/aoi/unit/instance/InstanceUsageBase.kt
@@ -29,6 +29,7 @@ import org.objectionary.aoi.process.InstanceUsageProcessor
 import org.objectionary.aoi.unit.UnitTestBase
 import org.objectionary.ddr.graph.repr.Graph
 import java.io.File
+import java.nio.file.Path
 
 /**
  * Base class for graph builder testing
@@ -39,13 +40,13 @@ open class InstanceUsageBase : UnitTestBase() {
         InstanceUsageProcessor(graph).processInstanceUsages()
     }
 
-    override fun constructOutPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructOutPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}out${sep}instance_usages$sep$directoryName.txt")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 
-    override fun constructInPath(directoryName: String): String =
-        File(System.getProperty("user.dir")).resolve(
+    override fun constructInPath(directoryName: String): Path =
+        Path.of(File(System.getProperty("user.dir")).resolve(
             File("src${sep}test${sep}resources${sep}unit${sep}in${sep}instance_usages$sep$directoryName")
-        ).absolutePath.replace("/", File.separator)
+        ).absolutePath.replace("/", File.separator))
 }


### PR DESCRIPTION
After [ddr](https://github.com/objectionary/ddr) release there were some compatibility issues. This PR is resolving them.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating dependencies and improving file path handling. 

### Detailed summary
- Updated the version of the `ddr` artifact from `0.0.10` to `0.0.11` in the `pom.xml` file.
- Modified the return type of the `constructInPath` and `constructOutPath` functions in several files from `String` to `Path`.
- Imported the `Path` class in several files.
- Replaced the usage of deprecated methods with alternative methods in the `UnitTestBase` class.
- Updated the return type of the `constructOutPath` function in the `UnitTestBase` class from `String` to `Path`.
- Updated the return type of the `constructOutPath` function in the `AtomsBase` class from `String` to `Path`.
- Imported the `getAttrContent` function from the `org.objectionary.ddr.util` package in several files.
- Removed unused imports in several files.

> The following files were skipped due to too many changes: `src/test/kotlin/org/objectionary/aoi/unit/atoms/AtomsBase.kt`, `src/main/kotlin/org/objectionary/aoi/process/AtomsProcessor.kt`, `src/main/kotlin/org/objectionary/aoi/launch/AoiWorkflow.kt`, `src/test/kotlin/org/objectionary/aoi/integration/IntegrationTestBase.kt`, `src/main/kotlin/org/objectionary/aoi/process/InstanceUsageProcessor.kt`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->